### PR TITLE
Отключение логов iqchannels-sdk

### DIFF
--- a/iqchannels-sdk/src/main/java/ru/iqchannels/sdk/Log.java
+++ b/iqchannels-sdk/src/main/java/ru/iqchannels/sdk/Log.java
@@ -1,0 +1,17 @@
+package ru.iqchannels.sdk;
+
+public class Log {
+    private static final boolean LOGGING = true;
+
+    public static void d(String tag, String message) {
+        if (LOGGING) android.util.Log.d(tag, message);
+    }
+
+    public static void i(String tag, String message) {
+        d(tag, message);
+    }
+
+    public static void e(String tag, String message) {
+        if (LOGGING) android.util.Log.e(tag, message);
+    }
+}

--- a/iqchannels-sdk/src/main/java/ru/iqchannels/sdk/Log.java
+++ b/iqchannels-sdk/src/main/java/ru/iqchannels/sdk/Log.java
@@ -1,7 +1,13 @@
 package ru.iqchannels.sdk;
 
 public class Log {
-    private static final boolean LOGGING = false;
+    private static boolean LOGGING = true;
+
+    public static void configure(boolean state) {
+        synchronized(Log.class) {
+            LOGGING = state;
+        }
+    }
 
     public static void d(String tag, String message) {
         if (LOGGING) android.util.Log.d(tag, message);

--- a/iqchannels-sdk/src/main/java/ru/iqchannels/sdk/Log.java
+++ b/iqchannels-sdk/src/main/java/ru/iqchannels/sdk/Log.java
@@ -1,7 +1,7 @@
 package ru.iqchannels.sdk;
 
 public class Log {
-    private static final boolean LOGGING = true;
+    private static final boolean LOGGING = false;
 
     public static void d(String tag, String message) {
         if (LOGGING) android.util.Log.d(tag, message);

--- a/iqchannels-sdk/src/main/java/ru/iqchannels/sdk/app/IQChannels.java
+++ b/iqchannels-sdk/src/main/java/ru/iqchannels/sdk/app/IQChannels.java
@@ -3,7 +3,6 @@ package ru.iqchannels.sdk.app;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Handler;
-import android.util.Log;
 import android.webkit.MimeTypeMap;
 
 import androidx.annotation.NonNull;
@@ -24,6 +23,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 
+import ru.iqchannels.sdk.Log;
 import ru.iqchannels.sdk.http.HttpCallback;
 import ru.iqchannels.sdk.http.HttpClient;
 import ru.iqchannels.sdk.http.HttpProgressCallback;

--- a/iqchannels-sdk/src/main/java/ru/iqchannels/sdk/app/IQChannelsConfig.java
+++ b/iqchannels-sdk/src/main/java/ru/iqchannels/sdk/app/IQChannelsConfig.java
@@ -1,5 +1,7 @@
 package ru.iqchannels.sdk.app;
 
+import ru.iqchannels.sdk.Log;
+
 public class IQChannelsConfig {
     public String address;
     public String channel;
@@ -7,7 +9,12 @@ public class IQChannelsConfig {
     public IQChannelsConfig() {}
 
     public IQChannelsConfig(String address, String channel) {
+        this(address, channel, true);
+    }
+
+    public IQChannelsConfig(String address, String channel, boolean logging) {
         this.address = address;
         this.channel = channel;
+        Log.configure(logging);
     }
 }

--- a/iqchannels-sdk/src/main/java/ru/iqchannels/sdk/http/HttpClient.java
+++ b/iqchannels-sdk/src/main/java/ru/iqchannels/sdk/http/HttpClient.java
@@ -2,7 +2,6 @@ package ru.iqchannels.sdk.http;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -27,6 +26,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import ru.iqchannels.sdk.Log;
 import ru.iqchannels.sdk.rels.Rels;
 import ru.iqchannels.sdk.schema.ChatEvent;
 import ru.iqchannels.sdk.schema.ChatEventQuery;

--- a/iqchannels-sdk/src/main/java/ru/iqchannels/sdk/http/HttpRequest.java
+++ b/iqchannels-sdk/src/main/java/ru/iqchannels/sdk/http/HttpRequest.java
@@ -6,7 +6,6 @@
 package ru.iqchannels.sdk.http;
 
 import android.annotation.SuppressLint;
-import android.util.Log;
 import android.util.StringBuilderPrinter;
 
 import androidx.annotation.NonNull;
@@ -36,6 +35,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
+import ru.iqchannels.sdk.Log;
 import ru.iqchannels.sdk.lib.InternalIO;
 import ru.iqchannels.sdk.schema.ChatException;
 import ru.iqchannels.sdk.schema.Relations;

--- a/iqchannels-sdk/src/main/java/ru/iqchannels/sdk/ui/ChatFragment.java
+++ b/iqchannels-sdk/src/main/java/ru/iqchannels/sdk/ui/ChatFragment.java
@@ -27,7 +27,6 @@ import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -50,6 +49,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 
+import ru.iqchannels.sdk.Log;
 import ru.iqchannels.sdk.R;
 import ru.iqchannels.sdk.app.Callback;
 import ru.iqchannels.sdk.app.Cancellable;


### PR DESCRIPTION
sdk содержит логи, которые работают при подключении библиотеки к реальным проектам, но по факту не нужны, а только засоряют output. Выключил, не затрагивая логику самого sdk, с возможностью включения для отладочных целей